### PR TITLE
CI: トークンに他のリポジトリへのアクセス権を付与

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           app-id: ${{ env.content_repository_app_id }}
           private-key: ${{ secrets.CONTENT_REPOSITORY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout production resources
         uses: actions/checkout@v4


### PR DESCRIPTION
デフォルトではこのリポジトリに対するアクセス権しか付与されないので、このリポジトリの所有者のリポジトリのうち、アプリ権限内で許可されているリポジトリに対してアクセス権を付与するようにします。