### PR TITLE
CI: ./resources/.git のコピーを防止

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ env.content_repository_app_id != ''}}
         run: |
             # ./resources/.git のコピーは危険なので防止
-            rsync -av --exclude ".git/" ./resources/ ./public/
+            rsync -av --exclude ".git/" ./resources/public/ ./public/
 
       - name: Setup Docker Buildx
         id: buildx

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -57,7 +57,9 @@ jobs:
         env:
           content_repository_app_id: ${{ vars.CONTENT_REPOSITORY_APP_ID }}
         if: ${{ env.content_repository_app_id != ''}}
-        run: rsync -av ./resources/ ./public/
+        run: |
+            # ./resources/.git のコピーは危険なので防止
+            rsync -av --exclude ".git/" ./resources/ ./public/
 
       - name: Setup Docker Buildx
         id: buildx


### PR DESCRIPTION
結構危ない気がする。

.git ディレクトリのコピーを防止します。

ディレクトリの位置も間違えていたので、 ./resources/public を ./public にコピーするように書き換えます。